### PR TITLE
React refactor playlists, closes #95

### DIFF
--- a/app/assets/javascripts/components/add_to_playlist.js.jsx
+++ b/app/assets/javascripts/components/add_to_playlist.js.jsx
@@ -13,9 +13,9 @@ class AddToPlaylist extends React.Component {
     $.ajax({
       url: "/api/v1/playlists.json",
       method: "GET",
-      data: {user_id: userId },
+      data: {user_id: userId},
       success: (response) => {
-        this.setState({ playlists: response });
+        this.setState({playlists: response});
         $("#playlists-listing").show();
       }
     });
@@ -29,12 +29,12 @@ class AddToPlaylist extends React.Component {
     $.ajax({
       url: "/api/v1/playlists/" + playlistId + ".json",
       method: "PATCH",
-      data: {user_id: userId, playlist_id: playlistId, track_uri: trackUri },
+      data: {user_id: userId, playlist_id: playlistId, track_uri: trackUri},
       success: () => {
         $("#add-to-playlist").hide();
         $("#playlists-listing").hide();
-        $("#added-message").slideDown( () => {
-          setTimeout( () => {
+        $("#added-message").slideDown(() => {
+          setTimeout(() => {
           $("#added-message").slideUp();
         }, 3000);
       });
@@ -48,10 +48,10 @@ class AddToPlaylist extends React.Component {
   }
 
   render() {
-    var playlists = this.state.playlists.map( (playlist) => {
-      return <PlaylistForAdd key={playlist.id} playlist={playlist} />
+    var playlists = this.state.playlists.map((playlist) => {
+      return <PlaylistForAdd key={playlist.id} playlist={playlist} />;
     });
-    return(
+    return (
       <div>
         <div className="row">
           <button onClick={this.getPlaylists.bind(this)} className="btn btn-success" id="add-to-playlist" type="button" name="button">Add to Playlist</button>

--- a/app/assets/javascripts/components/all_playlists.js.jsx
+++ b/app/assets/javascripts/components/all_playlists.js.jsx
@@ -2,7 +2,7 @@ class AllPlaylists extends React.Component {
 
   render () {
     var playlists = this.props.playlists.map( (playlist) => {
-      return <Playlist key= {playlist.table.id} playlist={playlist} />
+      return <Playlist key= {playlist.id} playlist={playlist} />
     });
     return (
       <div className='container'>
@@ -12,5 +12,5 @@ class AllPlaylists extends React.Component {
         </div>
       </div>
     );
-  };
-};
+  }
+}

--- a/app/assets/javascripts/components/playlist.js.jsx
+++ b/app/assets/javascripts/components/playlist.js.jsx
@@ -5,10 +5,10 @@ class Playlist extends React.Component {
 
   render() {
     return(
-      <div className='col-md-4' id={this.props.playlist.table.name}>
-        <h4>{this.props.playlist.table.name}</h4>
-        <iframe src={"https://embed.spotify.com/?uri=" + this.props.playlist.table.uri + "&theme=white"} width="300" height="380" frameBorder="0" allowTransparency="true"></iframe>
+      <div className='col-md-4' id={this.props.playlist.name}>
+        <h4>{this.props.playlist.name}</h4>
+        <iframe src={"https://embed.spotify.com/?uri=" + this.props.playlist.uri + "&theme=white"} width="300" height="380" frameBorder="0" allowTransparency="true"></iframe>
       </div>
     );
-  };
-};
+  }
+}

--- a/app/assets/javascripts/components/playlist.js.jsx
+++ b/app/assets/javascripts/components/playlist.js.jsx
@@ -1,10 +1,10 @@
 class Playlist extends React.Component {
   constructor(props) {
     super(props);
-  };
+  }
 
   render() {
-    return(
+    return (
       <div className='col-md-4' id={this.props.playlist.name}>
         <h4>{this.props.playlist.name}</h4>
         <iframe src={"https://embed.spotify.com/?uri=" + this.props.playlist.uri + "&theme=white"} width="300" height="380" frameBorder="0" allowTransparency="true"></iframe>

--- a/app/assets/javascripts/components/playlist_for_add.js.jsx
+++ b/app/assets/javascripts/components/playlist_for_add.js.jsx
@@ -1,11 +1,11 @@
 class PlaylistForAdd extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
   }
 
   render() {
-    return(
+    return (
       <option data-target={this.props.playlist.table.id}>{this.props.playlist.table.name}</option>
-    )
+    );
   }
 }

--- a/app/assets/javascripts/components/playlists.js.jsx
+++ b/app/assets/javascripts/components/playlists.js.jsx
@@ -1,19 +1,18 @@
 class Playlists extends React.Component {
   constructor(props) {
     super();
+    var formattedPlaylists = props.playlists.map( (playlist) => {
+      return playlist.table
+    });
     this.state = {
-      playlists: props.playlists
+      playlists: formattedPlaylists
     };
   }
 
   handleSubmit(playlist) {
-    $("input#new-playlist-name").val("");
-    $(".playlists-index-list").append(
-      "<div class='col-md-4' id=" + playlist.name + ">" +
-        "<h4>" + playlist.name + "<h4>" +
-        "<iframe src='https://embed.spotify.com/?uri=" + playlist.uri + "&theme=white' width='300' height='380' frameborder='0' allowtransparency='true'></iframe>" +
-      "</div>"
-    )
+    var newState = this.state.playlists.concat(playlist);
+    this.setState( {playlists: newState} );
+     $("input#new-playlist-name").val("");
   }
 
   render () {
@@ -22,7 +21,6 @@ class Playlists extends React.Component {
         <NewPlaylist handleSubmit={this.handleSubmit.bind(this)}/>
         <AllPlaylists playlists={this.state.playlists} />
       </div>
-
-    )
+    );
   }
 }

--- a/app/assets/javascripts/components/playlists.js.jsx
+++ b/app/assets/javascripts/components/playlists.js.jsx
@@ -1,8 +1,8 @@
 class Playlists extends React.Component {
   constructor(props) {
     super();
-    var formattedPlaylists = props.playlists.map( (playlist) => {
-      return playlist.table
+    var formattedPlaylists = props.playlists.map((playlist) => {
+      return playlist.table;
     });
     this.state = {
       playlists: formattedPlaylists
@@ -11,11 +11,11 @@ class Playlists extends React.Component {
 
   handleSubmit(playlist) {
     var newState = this.state.playlists.concat(playlist);
-    this.setState( {playlists: newState} );
-     $("input#new-playlist-name").val("");
+    this.setState({playlists: newState});
+    $("input#new-playlist-name").val("");
   }
 
-  render () {
+  render() {
     return (
       <div>
         <NewPlaylist handleSubmit={this.handleSubmit.bind(this)}/>


### PR DESCRIPTION
This PR refactors view code related to the app's "create playlist" functionality. When converting views to React, I initially left the "append" piece on lines 11-16 of /playlists.js.jsx. Because of a difference in format between the playlists in the array initially returned by the Spotify API, and the format of the newly-created playlist returned after a successful POST to the API, it did not work to simply 'setState' to the updated playlists array. The addition on /playlists/js.jsx lines 4-6 fixes this. 
